### PR TITLE
Timeseries population

### DIFF
--- a/src/app/Components/ObservationModal/observation-modal.service.ts
+++ b/src/app/Components/ObservationModal/observation-modal.service.ts
@@ -39,7 +39,19 @@ export class ObservationModalService {
                 })),
                 mergeMap(
                     (obs: Observation) => forkJoin({
-                        timeseries: this.timeseriesService.getTimeseriesById(obs.inTimeseries),
+                        timeseries: this.timeseriesService.getTimeseriesById(obs.inTimeseries, {
+                            populate: [
+                                'unit', 
+                                'observedProperty', 
+                                'disciplines', 
+                                'aggregation', 
+                                'hasFeatureOfInterest', 
+                                'usedProcedures',
+                                'hasDeployment',
+                                'ancestorPlatforms',
+                                'madeBySensor'
+                            ]
+                        }),
                         earliest: this.observationService.getFirstObservation(obs.observedProperty["@id"], obs.ancestorPlatforms[0]),
                     }), (observation, forkJoin) => {
                         return { observation, ...forkJoin }

--- a/src/app/Pages/ObservedProperty/observed-property.component.ts
+++ b/src/app/Pages/ObservedProperty/observed-property.component.ts
@@ -38,6 +38,19 @@ export class ObservedPropertyComponent implements OnInit {
                 includes: this.platform,
             },
             observedProperty: this.property
+        }, {
+            populate: [
+                // TODO: Do we actually need all these to be populated?
+                'unit', 
+                'observedProperty', 
+                'disciplines', 
+                'aggregation', 
+                'hasFeatureOfInterest', 
+                'usedProcedures',
+                'hasDeployment',
+                'ancestorPlatforms',
+                'madeBySensor'
+            ]
         })
         .pipe(map(({data}) => data))
         .toPromise()

--- a/src/app/Services/timeseries/timeseries.service.ts
+++ b/src/app/Services/timeseries/timeseries.service.ts
@@ -21,9 +21,10 @@ export class TimeSeriesService {
      * 
      * @param id : timeseries identifier
      */
-    public getTimeseriesById(id) {
+    public getTimeseriesById(id, options?: {populate?: string[]} = {}) {
 
-        return this.http.get(`${environment.apiUrl}/timeseries/${id}`)
+        const qs = this.apiFunctions.queryParamsObjectToString(options);
+        return this.http.get(`${environment.apiUrl}/timeseries/${id}${qs}`)
 
     }
 
@@ -32,9 +33,10 @@ export class TimeSeriesService {
      * 
      * @param where : query object
      */
-    public getTimeSeriesByQuery(where?: Object) {
+    public getTimeSeriesByQuery(where = {}, options: {populate?: string[]} = {}) {
 
-        const qs = this.apiFunctions.queryParamsObjectToString(where);
+        const queryParamsObject = Object.assign({}, where, options);
+        const qs = this.apiFunctions.queryParamsObjectToString(queryParamsObject);
 
         return this.http.get(`${environment.apiUrl}/timeseries${qs}`)
         .pipe(

--- a/src/app/Services/timeseries/timeseries.service.ts
+++ b/src/app/Services/timeseries/timeseries.service.ts
@@ -21,7 +21,7 @@ export class TimeSeriesService {
      * 
      * @param id : timeseries identifier
      */
-    public getTimeseriesById(id, options?: {populate?: string[]} = {}) {
+    public getTimeseriesById(id, options: {populate?: string[]} = {}) {
 
         const qs = this.apiFunctions.queryParamsObjectToString(options);
         return this.http.get(`${environment.apiUrl}/timeseries/${id}${qs}`)


### PR DESCRIPTION
@Gramcito the api has been updated so that timeseries (single or multiple) are no longer populated by default, i.e. observedProperty will be a string rather than an object with a label and description. However I've updated your code so that it asks for all the properties to be populated. We can decide at a later date if we actually need them all to the populated, as ultimately the more we populate the slower the response.

I'm guessing you want this merging into move-to-canvasjs rather that development?

The `populate` query parameter is described in the [api docs](https://stoplight.io/p/studio/gh/birminghamurbanobservatory/docs). 